### PR TITLE
Optimize image processing with persistent cache

### DIFF
--- a/config/markdown.js
+++ b/config/markdown.js
@@ -15,6 +15,8 @@ import {
 } from "@shikijs/transformers"
 import Image from "@11ty/eleventy-img"
 
+import { IMAGE_OPTIONS, generateImage } from "./utils/images.js"
+
 export const mdOptions = {
     typographer: true,
     html: true,
@@ -107,10 +109,6 @@ md.renderer.rules.heading_close = (tokens, idx, options, env, self) => {
 
 // Responsive Images
 // see: https://tomichen.com/blog/posts/20220416-responsive-images-in-markdown-with-eleventy-image/
-// Images render at most 768 CSS px wide (see the sizes attribute below), so
-// 768 and 1536 cover 1x and 2x retina exactly; intermediate or larger variants
-// are imperceptible overkill for this fixed column width.
-const IMAGE_WIDTHS = [768, 1536]
 md.renderer.rules.image = (tokens, idx, options, env, self) => {
     const token = tokens[idx]
     const naiveSrc = token.attrGet('src')
@@ -119,18 +117,11 @@ md.renderer.rules.image = (tokens, idx, options, env, self) => {
     const src = naiveSrc[0] === '/' ? './src' + naiveSrc : path.join(path.dirname(env.page.inputPath), naiveSrc)
     const alt = token.content
     const htmlAttributes = { alt, loading: 'lazy', decoding: 'async' }
-    const imgOpts = {
-        widths: IMAGE_WIDTHS,
-        formats: ['webp', 'jpeg', 'svg'],
-        urlPath: '/media/img/',
-        outputDir: './_site/media/img/',
-        // Lower webp encoding effort: effort only controls the compression
-        // search, not visual quality at a fixed quality value, so this speeds
-        // up the build at the cost of marginally larger files.
-        sharpWebpOptions: { effort: 2 },
-    }
-    Image(src, imgOpts)
-    const metadata = Image.statsSync(src, imgOpts)
+    // Kick off generation (writes to the persistent cache) and synchronously
+    // derive the metadata for the markup. generateImage tracks the promise so
+    // the build can wait for it before copying images into the output.
+    generateImage(src, IMAGE_OPTIONS)
+    const metadata = Image.statsSync(src, IMAGE_OPTIONS)
     const generated = Image.generateHTML(
         metadata,
         {

--- a/config/markdown.js
+++ b/config/markdown.js
@@ -107,7 +107,10 @@ md.renderer.rules.heading_close = (tokens, idx, options, env, self) => {
 
 // Responsive Images
 // see: https://tomichen.com/blog/posts/20220416-responsive-images-in-markdown-with-eleventy-image/
-const IMAGE_WIDTHS = [640, 1280, 1920]
+// Images render at most 768 CSS px wide (see the sizes attribute below), so
+// 768 and 1536 cover 1x and 2x retina exactly; intermediate or larger variants
+// are imperceptible overkill for this fixed column width.
+const IMAGE_WIDTHS = [768, 1536]
 md.renderer.rules.image = (tokens, idx, options, env, self) => {
     const token = tokens[idx]
     const naiveSrc = token.attrGet('src')
@@ -118,9 +121,13 @@ md.renderer.rules.image = (tokens, idx, options, env, self) => {
     const htmlAttributes = { alt, loading: 'lazy', decoding: 'async' }
     const imgOpts = {
         widths: IMAGE_WIDTHS,
-        formats: ['webp', 'jpeg', 'png', 'svg'],
+        formats: ['webp', 'jpeg', 'svg'],
         urlPath: '/media/img/',
         outputDir: './_site/media/img/',
+        // Lower webp encoding effort: effort only controls the compression
+        // search, not visual quality at a fixed quality value, so this speeds
+        // up the build at the cost of marginally larger files.
+        sharpWebpOptions: { effort: 2 },
     }
     Image(src, imgOpts)
     const metadata = Image.statsSync(src, imgOpts)

--- a/config/shortcodes/image.js
+++ b/config/shortcodes/image.js
@@ -2,13 +2,20 @@ import Image from "@11ty/eleventy-img"
 import { md } from '../markdown.js'
 import { errorBoundary } from './utils.js'
 
-const IMAGE_WIDTHS = [640, 1280, 1920]
+// Images render at most 768 CSS px wide (see the sizes attribute below), so
+// 768 and 1536 cover 1x and 2x retina exactly; intermediate or larger variants
+// are imperceptible overkill for this fixed column width.
+const IMAGE_WIDTHS = [768, 1536]
 const IMAGE_FORMATS = ['webp', 'jpeg', 'svg']
 const IMAGE_OPTIONS = {
     widths: IMAGE_WIDTHS,
     formats: IMAGE_FORMATS,
     urlPath: '/media/img/',
     outputDir: './_site/media/img/',
+    // Lower webp encoding effort: effort only controls the compression search,
+    // not visual quality at a fixed quality value, so this speeds up the build
+    // at the cost of marginally larger files.
+    sharpWebpOptions: { effort: 2 }
 }
 
 const image = async function (imgObj) {

--- a/config/shortcodes/image.js
+++ b/config/shortcodes/image.js
@@ -1,22 +1,7 @@
 import Image from "@11ty/eleventy-img"
 import { md } from '../markdown.js'
 import { errorBoundary } from './utils.js'
-
-// Images render at most 768 CSS px wide (see the sizes attribute below), so
-// 768 and 1536 cover 1x and 2x retina exactly; intermediate or larger variants
-// are imperceptible overkill for this fixed column width.
-const IMAGE_WIDTHS = [768, 1536]
-const IMAGE_FORMATS = ['webp', 'jpeg', 'svg']
-const IMAGE_OPTIONS = {
-    widths: IMAGE_WIDTHS,
-    formats: IMAGE_FORMATS,
-    urlPath: '/media/img/',
-    outputDir: './_site/media/img/',
-    // Lower webp encoding effort: effort only controls the compression search,
-    // not visual quality at a fixed quality value, so this speeds up the build
-    // at the cost of marginally larger files.
-    sharpWebpOptions: { effort: 2 }
-}
+import { IMAGE_OPTIONS, generateImage } from '../utils/images.js'
 
 const image = async function (imgObj) {
     const fileSlug = this.page.fileSlug
@@ -24,7 +9,7 @@ const image = async function (imgObj) {
     // in a subdirectory with the same name as the page slug
     const src = `./src/media/${fileSlug}/${imgObj.src}`
 
-    const metadata = await Image(src, IMAGE_OPTIONS)
+    const metadata = await generateImage(src, IMAGE_OPTIONS)
 
     const pictureTag = Image.generateHTML(metadata, {
         sizes: '(max-width: 768px) 100vw, 768px',

--- a/config/utils/images.js
+++ b/config/utils/images.js
@@ -1,0 +1,76 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+
+import Image from '@11ty/eleventy-img'
+
+/* Shared @11ty/eleventy-img configuration and disk-cache plumbing.
+ *
+ * Image processing dominates build time, so we lean on eleventy-img's
+ * "skip if the output already exists" behavior. The catch (described by
+ * https://www.zachleat.com/web/faster-builds-with-eleventy-img/) is that this
+ * only helps if the output directory survives between builds — and the build
+ * output (_site) is wiped on every build, and starts empty on every deploy.
+ *
+ * So we write generated images to a persistent cache directory instead, and
+ * copy them into the output directory once the build is done. The cache lives
+ * under .cache/, which is preserved across builds by hosts like Cloudflare
+ * Pages and Vercel (and is already where @11ty/eleventy-fetch caches data).
+ */
+
+// Where eleventy-img writes generated files (persisted across builds)
+export const IMAGE_CACHE_DIR = './.cache/eleventy-img/'
+
+// Where those files must end up in the published site
+export const IMAGE_PUBLISH_DIR = './_site/media/img/'
+
+// Public URL path referenced from the generated <picture> markup
+export const IMAGE_URL_PATH = '/media/img/'
+
+// Images render at most 768 CSS px wide (see the sizes attribute on output), so
+// 768 and 1536 cover 1x and 2x retina exactly; intermediate or larger variants
+// are imperceptible overkill for this fixed column width.
+export const IMAGE_WIDTHS = [768, 1536]
+
+// webp + jpeg cover every browser; svg passes through untouched for svg sources.
+export const IMAGE_FORMATS = ['webp', 'jpeg', 'svg']
+
+export const IMAGE_OPTIONS = {
+  widths: IMAGE_WIDTHS,
+  formats: IMAGE_FORMATS,
+  urlPath: IMAGE_URL_PATH,
+  outputDir: IMAGE_CACHE_DIR,
+  // Lower webp encoding effort: effort only controls the compression search,
+  // not visual quality at a fixed quality value, so this speeds up the build
+  // at the cost of marginally larger files.
+  sharpWebpOptions: { effort: 2 }
+}
+
+// Track every in-flight generation so the build can wait for all images to be
+// written to the cache before copying them into the output directory. The
+// markdown image renderer in particular cannot await generation directly
+// (markdown-it render rules are synchronous), so it registers its work here.
+const pending = []
+
+export function generateImage(src, options = IMAGE_OPTIONS) {
+  const promise = Image(src, options)
+  pending.push(promise)
+  return promise
+}
+
+// Copy the images generated during this build out of the persistent cache and
+// into the published output directory. Only files referenced this build are
+// copied, so stale variants left in the cache don't bloat the deploy.
+export async function copyGeneratedImagesToOutput() {
+  const results = await Promise.allSettled(pending)
+  await fs.mkdir(IMAGE_PUBLISH_DIR, { recursive: true })
+  const copied = new Set()
+  await Promise.all(results.flatMap((result) => {
+    if (result.status !== 'fulfilled') return []
+    return Object.values(result.value).flat().flatMap((entry) => {
+      if (copied.has(entry.filename)) return []
+      copied.add(entry.filename)
+      return fs.copyFile(entry.outputPath, path.join(IMAGE_PUBLISH_DIR, entry.filename))
+    })
+  }))
+  return copied.size
+}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -17,6 +17,7 @@ import yaml from "js-yaml"
 import { compileObservable } from "./config/utils/ojs/compile.js"
 import { md } from './config/markdown.js'
 import shortcodes from './config/shortcodes/index.js'
+import { copyGeneratedImagesToOutput } from './config/utils/images.js'
 
 import {
     numFormat,
@@ -69,6 +70,19 @@ export default function(eleventyConfig) {
             }
         ))
         console.log("[11ty] Finished copying source files to output directory")
+    })
+
+    /* Copy cached responsive images into the output directory
+     *
+     * eleventy-img writes to a persistent cache (.cache/) so unchanged source
+     * images aren't reprocessed on subsequent builds; the build output is wiped
+     * each build, so the generated images need to be copied back in here.
+     * See: https://www.zachleat.com/web/faster-builds-with-eleventy-img/
+     *-------------------------------------*/
+    eleventyConfig.on('eleventy.after', async () => {
+        console.log("[11ty] Copying generated images from cache to output directory...")
+        const count = await copyGeneratedImagesToOutput()
+        console.log(`[11ty] Finished copying ${count} generated images to output directory`)
     })
 
     /* Run ESBuild after building site


### PR DESCRIPTION
## Summary
Refactors image processing to use a persistent cache directory that survives between builds, significantly improving build performance by avoiding reprocessing of unchanged images.

## Key Changes
- **New `config/utils/images.js` module**: Centralizes `@11ty/eleventy-img` configuration and implements a disk-cache strategy
  - Exports shared `IMAGE_OPTIONS` configuration used across the codebase
  - Implements `generateImage()` function that tracks in-flight image generation promises
  - Implements `copyGeneratedImagesToOutput()` to copy cached images into the published output after the build completes
  - Images are written to `.cache/eleventy-img/` (persisted across builds) instead of directly to `_site/`

- **Updated `config/markdown.js`**: Uses the new centralized image utilities
  - Imports `IMAGE_OPTIONS` and `generateImage` from the new utils module
  - Removes duplicate image configuration
  - Calls `generateImage()` to track async work while synchronously deriving metadata for markup generation

- **Updated `config/shortcodes/image.js`**: Uses the new centralized image utilities
  - Imports `IMAGE_OPTIONS` and `generateImage` from the new utils module
  - Removes duplicate image configuration
  - Calls `generateImage()` instead of `Image()` directly to track async work

- **Updated `eleventy.config.js`**: Adds post-build hook to copy cached images
  - Imports `copyGeneratedImagesToOutput` from the new utils module
  - Registers `eleventy.after` event listener to copy generated images from cache to output directory after the build completes

## Implementation Details
- Image widths reduced from `[640, 1280, 1920]` to `[768, 1536]` to match the fixed 768px column width (covers 1x and 2x retina exactly)
- WebP encoding effort lowered to 2 for faster builds with marginally larger files
- SVG format handling preserved; PNG removed in favor of WebP + JPEG coverage
- Promise tracking allows markdown renderer (which is synchronous) to register async image generation work that the build waits for before copying images to output
- Only images referenced in the current build are copied to output, preventing stale variants from bloating the deploy

https://claude.ai/code/session_01UaKqfiZq1ZVMtjbfqhvfqc